### PR TITLE
Add missing catch all handle_info function

### DIFF
--- a/lib/logger_syslog_backend.ex
+++ b/lib/logger_syslog_backend.ex
@@ -38,6 +38,10 @@ defmodule LoggerSyslogBackend do
     {:ok, %{state | socket: nil}}
   end
 
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
   ## Helpers
 
   defp configure(name, opts) do


### PR DESCRIPTION
Without this catch all handle_info there are some errors like:

(FunctionClauseError) no function clause matching in LoggerSyslogBackend.handle_info/2
    (logger_syslog_backend 1.0.1) lib/logger_syslog_backend.ex:33: LoggerSyslogBackend.handle_info({Logger.Config, :update_counter}, %{app_id: :app, buffer: nil, facility: 144, format: ["[", :level, "] ", :levelpad, :metadata, " ", :message], level: nil, metadata: [:module, :function], name: nil, path: '/dev/log', socket: nil})