### PR TITLE
minor updates for Elixir >= 1.14.0 to remove compile-time warnings

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/logger_syslog_backend.ex
+++ b/lib/logger_syslog_backend.ex
@@ -2,9 +2,9 @@ defmodule LoggerSyslogBackend do
   @moduledoc false
 
   @behaviour :gen_event
-  use Bitwise
+  import Bitwise
 
-  @default_format "[$level] $levelpad$metadata $message"
+  @default_format "[$level] $metadata $message"
 
   def init({__MODULE__, name}) do
     {:ok, configure(name, [])}

--- a/lib/logger_syslog_backend.ex
+++ b/lib/logger_syslog_backend.ex
@@ -73,7 +73,8 @@ defmodule LoggerSyslogBackend do
     buffer = Keyword.get(opts, :buffer)
 
     path =
-      Keyword.get_lazy(opts, :path, fn -> default_path() end) |> IO.iodata_to_binary()
+      Keyword.get_lazy(opts, :path, fn -> default_path() end)
+      |> IO.iodata_to_binary()
       |> String.to_charlist()
 
     %{
@@ -116,7 +117,7 @@ defmodule LoggerSyslogBackend do
     app_id = app_id || Application.get_application(md[:module] || :elixir)
 
     pre =
-      :io_lib.format('<~B>~s ~s ~p: ', [
+      :io_lib.format(~c"<~B>~s ~s ~p: ", [
         facility ||| severity(level),
         timestamp(ts),
         app_id,

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,16 @@ defmodule LoggerSyslogBackend.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :logger_syslog_backend,
-     version: "1.0.2",
-     elixir: "~> 1.5",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :logger_syslog_backend,
+      version: "1.0.2",
+      elixir: "~> 1.5",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
@@ -24,10 +26,12 @@ defmodule LoggerSyslogBackend.Mixfile do
   end
 
   defp package do
-    [files: ["lib", "mix.exs", "README.md", "LICENSE"],
-     maintainers: ["Paulo Almeida"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/pma/logger_syslog_backend"}]
+    [
+      files: ["lib", "mix.exs", "README.md", "LICENSE"],
+      maintainers: ["Paulo Almeida"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/pma/logger_syslog_backend"}
+    ]
   end
 
   # Dependencies can be Hex packages:
@@ -40,6 +44,6 @@ defmodule LoggerSyslogBackend.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:ex_doc, "~> 0.17", only: :dev},]
+    [{:ex_doc, "~> 0.17", only: :dev}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule LoggerSyslogBackend.Mixfile do
   def project do
     [
       app: :logger_syslog_backend,
-      version: "1.0.2",
-      elixir: "~> 1.5",
+      version: "1.0.3",
+      elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -44,6 +44,6 @@ defmodule LoggerSyslogBackend.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:ex_doc, "~> 0.17", only: :dev}]
+    [{:ex_doc, "~> 0.32", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,9 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.39", "424642f8335b05bb9eb611aa1564c148a8ee35c9c8a8bba6e129d51a3e3c6769", [:mix], [], "hexpm", "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944"},
+  "ex_doc": {:hex, :ex_doc, "0.32.1", "21e40f939515373bcdc9cffe65f3b3543f05015ac6c3d01d991874129d173420", [:mix], [{:earmark_parser, "~> 1.4.39", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_c, ">= 0.1.1", [hex: :makeup_c, repo: "hexpm", optional: true]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "5142c9db521f106d61ff33250f779807ed2a88620e472ac95dc7d59c380113da"},
+  "makeup": {:hex, :makeup, "1.1.1", "fa0bc768698053b2b3869fa8a62616501ff9d11a562f3ce39580d60860c3a55e", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5dc62fbdd0de44de194898b6710692490be74baa02d9d108bc29f007783b0b48"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.16.2", "627e84b8e8bf22e60a2579dad15067c755531fea049ae26ef1020cad58fe9578", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.5", "e0ff5a7c708dda34311f7522a8758e23bfcd7d8d8068dc312b5eb41c6fd76eba", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "94d2e986428585a21516d7d7149781480013c56e30c6a233534bedf38867a59a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+}


### PR DESCRIPTION
- remove [deprecated levelpad](https://github.com/elixir-lang/elixir/issues/11629)
- import Bitwise to drop another warning
- update ex_doc to latest
- appease mix format