### PR TITLE
rewrite erlang-generated log level from warn -> warning

### DIFF
--- a/lib/logger_syslog_backend.ex
+++ b/lib/logger_syslog_backend.ex
@@ -18,6 +18,11 @@ defmodule LoggerSyslogBackend do
     {:ok, state}
   end
 
+  # erlang processes may still send :warn events
+  def handle_event({:warn, gl, event}, state) do
+    handle_event({:warning, gl, event}, state)
+  end
+
   def handle_event({level, _gl, {Logger, msg, ts, md}}, %{level: min_level} = state) do
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
       log_event(level, msg, ts, md, state)

--- a/lib/logger_syslog_backend.ex
+++ b/lib/logger_syslog_backend.ex
@@ -143,6 +143,7 @@ defmodule LoggerSyslogBackend do
   defp severity(:debug), do: 7
   defp severity(:info), do: 6
   defp severity(:warn), do: 4
+  defp severity(:warning), do: 4
   defp severity(:error), do: 3
 
   defp facility_code(:local0), do: 16 <<< 3


### PR DESCRIPTION
This might not be the best way to handle this error but it's very convenient.

I often use 3rd party dependencies in the erlang ecosystem, that emit
`:warn` instead of `:warning` levels, which creates a duplicate notification
from Logger every time. This is very annoying:

```
warning: the log level :warn is deprecated, use :warning instead
  (logger 1.18.4) lib/logger.ex:1210: Logger.elixir_level_to_erlang_level/1
  (logger 1.18.4) lib/logger.ex:660: Logger.compare_levels/2
  (logger_syslog_backend 1.0.3) lib/logger_syslog_backend.ex:22: LoggerSyslogBackend.handle_event/2
  (stdlib 6.2.2) gen_event.erl:1921: :gen_event.server_update/4
  (stdlib 6.2.2) gen_event.erl:1903: :gen_event.server_notify/4
  (stdlib 6.2.2) gen_event.erl:1640: :gen_event.handle_msg/6
  (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

etc.

If this is a suitable fix, please tag 1.0.4 as well afterwards! thanks :melon: :mango: :kiwi_fruit: 